### PR TITLE
fixing e2e test

### DIFF
--- a/server/e2e-tests/kollaboraatioterminaali_e2e.test.js
+++ b/server/e2e-tests/kollaboraatioterminaali_e2e.test.js
@@ -5,7 +5,7 @@ describe('Kollaboraatioterminaali', () => {
     test('Etusivu aukeaa', async ({ page }) => {
         await page.goto('https://kollabterm.fly.dev/');
         expect(await page.title()).toBe('Collaboration terminal');
-        expect (await page.locator('text=Collaboration terminal (Change name?)').isVisible()).toBeTruthy();
+        expect (await page.locator('text=Kollabterm').isVisible()).toBeTruthy();
     });
 
     test('Käyttäjä voi kirjautua sisään', async ({ page }) => {


### PR DESCRIPTION
Virheellinen sivuston nimi e2e testissä, joka johti testin epäonnistumiseen ja katkaisee deploy pipelinen